### PR TITLE
Use generated API client for auth

### DIFF
--- a/app/lib/apiClient.ts
+++ b/app/lib/apiClient.ts
@@ -1,0 +1,7 @@
+import { client } from './openapi-client/client.gen';
+
+client.setConfig({
+  baseUrl: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000',
+});
+
+export { client };


### PR DESCRIPTION
## Summary
- switch AuthProvider to use generated OpenAPI client
- add helper to configure API client with runtime URL

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab0ef6d64832fab23e43654701ddf