### PR TITLE
Add Socket.IO integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Realtime Socket.IO Integration
+
+See [`docs/realtime-socketio.md`](docs/realtime-socketio.md) for details on connecting to the API's realtime Gateway using Socket.IO.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AuthProvider } from "@/components/AuthProvider";
+import { GatewayProvider } from "@/components/GatewayProvider";
 import { Toaster } from "@/components/ui/toaster";
 import CookieBanner from "@/components/CookieBanner";
 import { AvailableLocale, getDictionary } from "@/lib/dictionaries";
@@ -31,7 +32,8 @@ export default async function RootLayout(
   return (
     <html lang={lang || "fi"} className={inter.className}>
       <AuthProvider>
-        <body className={`bg-white text-black ${inter.className} antialiased`}>
+        <GatewayProvider>
+          <body className={`bg-white text-black ${inter.className} antialiased`}>
           <div className="flex flex-col min-h-screen">
             <header className="bg-white shadow-sm">
               <Navigation dict={dict} />
@@ -45,7 +47,8 @@ export default async function RootLayout(
             </main>
             <Footer dict={dict} />
           </div>
-        </body>
+          </body>
+        </GatewayProvider>
       </AuthProvider>
     </html>
   );

--- a/components/GatewayProvider.tsx
+++ b/components/GatewayProvider.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { createContext, useContext, useEffect, useRef } from 'react';
+import { Socket } from 'socket.io-client';
+import { useAuth } from './AuthProvider';
+import { connect } from '@/lib/socket';
+
+interface GatewayContextValue {
+  socket: Socket | null;
+}
+
+const GatewayContext = createContext<GatewayContextValue>({ socket: null });
+
+export function GatewayProvider({ children }: { children: React.ReactNode }) {
+  const { tokens } = useAuth();
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    if (!tokens?.accessToken) return;
+
+    const s = connect(tokens.accessToken);
+    socketRef.current = s;
+
+    const handleExpress = ({ orderId }: { orderId: string }) => {
+      console.log('New express order', orderId);
+    };
+
+    const handleTicket = ({ userId }: { userId: string }) => {
+      console.log('New support ticket from', userId);
+    };
+
+    s.on('express:new', handleExpress);
+    s.on('ticket:new', handleTicket);
+
+    return () => {
+      s.off('express:new', handleExpress);
+      s.off('ticket:new', handleTicket);
+      s.disconnect();
+      socketRef.current = null;
+    };
+  }, [tokens?.accessToken]);
+
+  return (
+    <GatewayContext.Provider value={{ socket: socketRef.current }}>
+      {children}
+    </GatewayContext.Provider>
+  );
+}
+
+export function useGateway() {
+  return useContext(GatewayContext);
+}

--- a/docs/realtime-socketio.md
+++ b/docs/realtime-socketio.md
@@ -1,0 +1,135 @@
+Realtime Socket.IO Integration Guide
+====================================
+
+This guide explains how to connect a frontend application to the realtime Gateway provided by this API. The examples use TypeScript.
+
+## Server URL
+
+The Socket.IO server is exposed from the same origin as the REST API. Connections use the path `/ws` and must send a valid access token obtained from the `/auth/login` or `/auth/refresh` endpoints.
+
+```ts
+const socket = io('http://localhost:3000', {
+  path: '/ws',
+  auth: { token: ACCESS_TOKEN },
+});
+```
+
+On connection the backend places the client in rooms based on the authenticated user ID and role. Events are emitted only to the relevant rooms.
+
+### Events
+
+| Event name   | Payload                     | Description                                     |
+|--------------|-----------------------------|-------------------------------------------------|
+| `express:new`| `{ orderId: string }`       | A new express order available for contractors   |
+| `ticket:new` | `{ userId: string }`        | A customer service ticket for admins            |
+
+Additional events may be added in future updates.
+
+---
+
+## React Native (Expo)
+
+1. Install the Socket.IO client for React Native.
+
+```sh
+bun add socket.io-client
+```
+
+2. Create a module to handle the connection.
+
+```ts
+// lib/socket.ts
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export const connect = (token: string) => {
+  socket = io('https://your-api-url.com', {
+    path: '/ws',
+    auth: { token },
+  });
+  return socket;
+};
+
+export const getSocket = () => socket;
+```
+
+3. Use the connection in your components.
+
+```ts
+import React, { useEffect } from 'react';
+import { connect } from '../lib/socket';
+
+export default function App() {
+  useEffect(() => {
+    const s = connect(ACCESS_TOKEN);
+    s.on('express:new', ({ orderId }) => {
+      console.log('New express order', orderId);
+    });
+  }, []);
+
+  return null;
+}
+```
+
+---
+
+## Next.js (App Router)
+
+1. Add the Socket.IO client.
+
+```sh
+bun add socket.io-client
+```
+
+2. Create a React hook for the connection.
+
+```ts
+// lib/useSocket.ts
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+export function useSocket(token: string) {
+  const socketRef = useRef<Socket>();
+
+  useEffect(() => {
+    socketRef.current = io('https://your-api-url.com', {
+      path: '/ws',
+      auth: { token },
+    });
+
+    return () => {
+      socketRef.current?.disconnect();
+    };
+  }, [token]);
+
+  return socketRef;
+}
+```
+
+3. Listen for events inside components.
+
+```tsx
+import { useSocket } from '../lib/useSocket';
+
+export default function Page() {
+  const socketRef = useSocket(ACCESS_TOKEN);
+
+  useEffect(() => {
+    const socket = socketRef.current;
+    if (!socket) return;
+
+    socket.on('ticket:new', ({ userId }) => {
+      console.log('New support ticket from', userId);
+    });
+
+    return () => {
+      socket.off('ticket:new');
+    };
+  }, [socketRef]);
+
+  return <div />;
+}
+```
+
+This setup will keep your front‑end in sync with realtime updates from the API for contractors, consumers and admins.

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -1,0 +1,13 @@
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export const connect = (token: string): Socket => {
+  socket = io(process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000', {
+    path: '/ws',
+    auth: { token },
+  });
+  return socket;
+};
+
+export const getSocket = () => socket;

--- a/lib/useSocket.ts
+++ b/lib/useSocket.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+export function useSocket(token: string) {
+  const socketRef = useRef<Socket>();
+
+  useEffect(() => {
+    socketRef.current = io(process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000', {
+      path: '/ws',
+      auth: { token },
+    });
+
+    return () => {
+      socketRef.current?.disconnect();
+    };
+  }, [token]);
+
+  return socketRef;
+}


### PR DESCRIPTION
## Summary
- document how to connect to the realtime gateway using Socket.IO
- link the new guide from the project README
- connect to the realtime Gateway in the app using a new `GatewayProvider`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2163c504832fa7a6192ff1f0ee1e