### PR TITLE
Implement category update for admin

### DIFF
--- a/app/[locale]/(dashboards)/admin/categories/CategoryAdminTable.tsx
+++ b/app/[locale]/(dashboards)/admin/categories/CategoryAdminTable.tsx
@@ -17,6 +17,7 @@ import { toast } from "@/hooks/use-toast";
 import {
   getCategories,
   createCategory,
+  updateCategory,
   deleteCategory,
 } from "@/app/lib/services/categoryService";
 import {
@@ -65,11 +66,17 @@ export default function CategoryAdminTable({
     setLoading(true);
     try {
       if (editCategory) {
-        // TODO: implement updateCategory
-        toast({
-          title: "Not implemented",
-          description: "Update not implemented yet",
+        const updated = await updateCategory(accessToken, editCategory.id, {
+          name: form.name,
+          imageUrl: "",
+          description: "",
+          express: editCategory.express ?? false,
+          expressPrice: editCategory.expressPrice ?? null,
         });
+        setCategories((prev) =>
+          prev.map((c) => (c.id === editCategory.id ? { ...c, ...updated } : c))
+        );
+        toast({ title: "Category updated" });
       } else {
         const newCat = await createCategory(accessToken, {
           name: form.name,

--- a/app/lib/services/categoryService.ts
+++ b/app/lib/services/categoryService.ts
@@ -42,6 +42,38 @@ const createCategory = async (
   return res.data;
 };
 
+const updateCategory = async (
+  accessToken: string | undefined,
+  categoryId: string,
+  category: CreateCategoryBody
+) => {
+  const token = resolveToken(accessToken);
+  if (!token) {
+    throw new Error("No access token available");
+  }
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000"}/admin/categories/${categoryId}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(category),
+    }
+  );
+  if (!res.ok) {
+    let err;
+    try {
+      err = await res.json();
+    } catch {
+      err = { message: res.statusText };
+    }
+    throw new Error(err.message);
+  }
+  return res.json();
+};
+
 const deleteCategory = async (accessToken: string | undefined, categoryId: string) => {
   const token = resolveToken(accessToken);
   if (!token) {
@@ -61,4 +93,4 @@ const deleteCategory = async (accessToken: string | undefined, categoryId: strin
   return res.data;
 };
 
-export { getCategories, createCategory, deleteCategory };
+export { getCategories, createCategory, updateCategory, deleteCategory };


### PR DESCRIPTION
## Summary
- add category update API call
- wire up update button in admin table so CRUD is complete

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3869f4e8832f93539be73c1bb634