### PR TITLE
Improve dashboard performance

### DIFF
--- a/app/[locale]/(lander)/yrityksesta/page.tsx
+++ b/app/[locale]/(lander)/yrityksesta/page.tsx
@@ -20,7 +20,7 @@ export default async function Page({
           width={1000}
           height={1000}
           className="my-12 rounded-md w-full"
-          priority
+          loading="lazy"
         />
       </section>
 

--- a/app/lib/services/analyticsService.ts
+++ b/app/lib/services/analyticsService.ts
@@ -1,10 +1,22 @@
 import { getLandingPageAnalytics as getLandingPageAnalyticsApi } from "../openapi-client";
 import { resolveToken } from "./util";
 
+type CacheEntry<T> = {
+  data: T;
+  timestamp: number;
+};
+
+const analyticsCache = new Map<string, CacheEntry<unknown>>();
+const CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+
 const getLandingPageAnalytics = async (accessToken?: string) => {
   const token = resolveToken(accessToken);
   if (!token) {
     throw new Error("No access token available");
+  }
+  const cached = analyticsCache.get(token);
+  if (cached && Date.now() - cached.timestamp < CACHE_DURATION_MS) {
+    return cached.data as unknown;
   }
   const res = await getLandingPageAnalyticsApi({
     headers: {
@@ -14,6 +26,7 @@ const getLandingPageAnalytics = async (accessToken?: string) => {
   if (res.error) {
     throw new Error(res.error.message);
   }
+  analyticsCache.set(token, { data: res.data, timestamp: Date.now() });
   return res.data;
 };
 


### PR DESCRIPTION
## Summary
- lazy load large roof image on company page
- cache admin dashboard analytics service

## Testing
- `npm run lint` *(fails: React Hook useTranslations is called in function getLoginSchema ...)*
- `npm run build` *(fails to compile: can't resolve '../lib/services/userService')*

------
https://chatgpt.com/codex/tasks/task_e_686e38a2d39c832fa96452bf9de99442