### PR TITLE
feat: add deleted users management page

### DIFF
--- a/app/(dashboards)/admin/deleted-users/DeletedUserAdminTable.tsx
+++ b/app/(dashboards)/admin/deleted-users/DeletedUserAdminTable.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+import { DeletedUser } from "@/app/lib/types/deletedUserTypes";
+
+interface Props {
+  initialUsers: DeletedUser[];
+  accessToken: string;
+}
+
+export default function DeletedUserAdminTable({ initialUsers }: Props) {
+  const [users] = useState(initialUsers);
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Deleted At</TableHead>
+          <TableHead>Anonymized At</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {users.map((user) => (
+          <TableRow key={user.id}>
+            <TableCell>{user.email}</TableCell>
+            <TableCell>{user.role}</TableCell>
+            <TableCell>{user.deletedAt}</TableCell>
+            <TableCell>{user.anonymizedAt ?? "-"}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/app/(dashboards)/admin/deleted-users/page.tsx
+++ b/app/(dashboards)/admin/deleted-users/page.tsx
@@ -1,0 +1,11 @@
+import { getDeletedUsers } from "@/app/lib/services/deletedUserService";
+import { getaccessToken } from "@/app/lib/actions";
+import DeletedUserAdminTable from "./DeletedUserAdminTable";
+
+export default async function DeletedUsersPage() {
+  const accessToken = await getaccessToken();
+  const users = await getDeletedUsers(accessToken);
+  return (
+    <DeletedUserAdminTable initialUsers={users} accessToken={accessToken} />
+  );
+}

--- a/app/lib/services/deletedUserService.ts
+++ b/app/lib/services/deletedUserService.ts
@@ -1,0 +1,23 @@
+import { getDeletedUsers as getDeletedUsersApi } from "../openapi-client";
+import { GetDeletedUsersResponse } from "../types/deletedUserTypes";
+import { resolveToken } from "./util";
+
+const getDeletedUsers = async (
+  accessToken: string | undefined,
+): Promise<GetDeletedUsersResponse> => {
+  const token = resolveToken(accessToken);
+  if (!token) {
+    throw new Error("No access token available");
+  }
+  const res = await getDeletedUsersApi({
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (res.error) {
+    throw new Error(res.error.message);
+  }
+  return res.data;
+};
+
+export { getDeletedUsers };

--- a/app/lib/types/deletedUserTypes.ts
+++ b/app/lib/types/deletedUserTypes.ts
@@ -1,0 +1,7 @@
+import { GetDeletedUsersResponse as GetDeletedUsersResponseApi } from "../openapi-client";
+
+type GetDeletedUsersResponse = GetDeletedUsersResponseApi;
+
+type DeletedUser = GetDeletedUsersResponse[number];
+
+export type { GetDeletedUsersResponse, DeletedUser };

--- a/components/admin-sidebar.tsx
+++ b/components/admin-sidebar.tsx
@@ -8,9 +8,10 @@ import {
   Settings,
   Users,
   Package,
-  MessageSquare, 
+  MessageSquare,
   LogOut,
   User,
+  UserX,
   Tag,
 } from "lucide-react";
 
@@ -68,6 +69,11 @@ const data = {
       title: "Users",
       url: "/admin/users",
       icon: Users,
+    },
+    {
+      title: "Deleted Users",
+      url: "/admin/deleted-users",
+      icon: UserX,
     },
     {
       title: "Contractors",


### PR DESCRIPTION
## Summary
- add navigation link for deleted users management
- display deleted users with new page and table
- add service and types for deleted users using openapi client

## Testing
- `npm test`
- `npm run lint` *(fails: 'error' is defined but never used)*


------
https://chatgpt.com/codex/tasks/task_e_68a5758bcabc832f87fbcf6d80e93af0